### PR TITLE
Add game mechanics component/system pairs

### DIFF
--- a/ECS/Components/AIBehaviorComponent.swift
+++ b/ECS/Components/AIBehaviorComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct AIBehaviorComponent: Component {
+    var state: Int = 0
+}

--- a/ECS/Components/AmmoComponent.swift
+++ b/ECS/Components/AmmoComponent.swift
@@ -1,0 +1,7 @@
+import RealityKit
+import Foundation
+
+struct AmmoComponent: Component {
+    var count: Int = 0
+    var capacity: Int = 0
+}

--- a/ECS/Components/CollectibleComponent.swift
+++ b/ECS/Components/CollectibleComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct CollectibleComponent: Component {
+    var collected: Bool = false
+}

--- a/ECS/Components/CooldownComponent.swift
+++ b/ECS/Components/CooldownComponent.swift
@@ -1,0 +1,8 @@
+import RealityKit
+import Foundation
+
+struct CooldownComponent: Component {
+    var time: TimeInterval = 1
+    var timer: TimeInterval = 0
+    var ready: Bool = true
+}

--- a/ECS/Components/DamageComponent.swift
+++ b/ECS/Components/DamageComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct DamageComponent: Component {
+    var amount: Float = 0
+}

--- a/ECS/Components/DamageOverTimeComponent.swift
+++ b/ECS/Components/DamageOverTimeComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct DamageOverTimeComponent: Component {
+    var rate: Float = 0
+}

--- a/ECS/Components/DialogComponent.swift
+++ b/ECS/Components/DialogComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct DialogComponent: Component {
+    var index: Int = 0
+}

--- a/ECS/Components/EnemySpawnComponent.swift
+++ b/ECS/Components/EnemySpawnComponent.swift
@@ -1,0 +1,7 @@
+import RealityKit
+import Foundation
+
+struct EnemySpawnComponent: Component {
+    var interval: TimeInterval = 5
+    var timer: TimeInterval = 0
+}

--- a/ECS/Components/ExperienceComponent.swift
+++ b/ECS/Components/ExperienceComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct ExperienceComponent: Component {
+    var points: Int = 0
+}

--- a/ECS/Components/FireRateComponent.swift
+++ b/ECS/Components/FireRateComponent.swift
@@ -1,0 +1,8 @@
+import RealityKit
+import Foundation
+
+struct FireRateComponent: Component {
+    var interval: TimeInterval = 1
+    var timer: TimeInterval = 0
+    var canFire: Bool = true
+}

--- a/ECS/Components/HealComponent.swift
+++ b/ECS/Components/HealComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct HealComponent: Component {
+    var amount: Float = 0
+}

--- a/ECS/Components/HealthComponent.swift
+++ b/ECS/Components/HealthComponent.swift
@@ -1,0 +1,7 @@
+import RealityKit
+import Foundation
+
+struct HealthComponent: Component {
+    var value: Float = 100
+    var max: Float = 100
+}

--- a/ECS/Components/InputComponent.swift
+++ b/ECS/Components/InputComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct InputComponent: Component {
+    var isActive: Bool = false
+}

--- a/ECS/Components/InteractionComponent.swift
+++ b/ECS/Components/InteractionComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct InteractionComponent: Component {
+    var triggered: Bool = false
+}

--- a/ECS/Components/InventoryComponent.swift
+++ b/ECS/Components/InventoryComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct InventoryComponent: Component {
+    var items: [String] = []
+}

--- a/ECS/Components/LevelComponent.swift
+++ b/ECS/Components/LevelComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct LevelComponent: Component {
+    var value: Int = 1
+}

--- a/ECS/Components/PathFollowComponent.swift
+++ b/ECS/Components/PathFollowComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct PathFollowComponent: Component {
+    var index: Int = 0
+}

--- a/ECS/Components/PickupComponent.swift
+++ b/ECS/Components/PickupComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct PickupComponent: Component {
+    var picked: Bool = false
+}

--- a/ECS/Components/QuestComponent.swift
+++ b/ECS/Components/QuestComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct QuestComponent: Component {
+    var completed: Bool = false
+}

--- a/ECS/Components/RespawnComponent.swift
+++ b/ECS/Components/RespawnComponent.swift
@@ -1,0 +1,7 @@
+import RealityKit
+import Foundation
+
+struct RespawnComponent: Component {
+    var time: TimeInterval = 5
+    var timer: TimeInterval = 0
+}

--- a/ECS/Components/ScoreComponent.swift
+++ b/ECS/Components/ScoreComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct ScoreComponent: Component {
+    var value: Int = 0
+}

--- a/ECS/Components/ShieldComponent.swift
+++ b/ECS/Components/ShieldComponent.swift
@@ -1,0 +1,7 @@
+import RealityKit
+import Foundation
+
+struct ShieldComponent: Component {
+    var strength: Float = 100
+    var max: Float = 100
+}

--- a/ECS/Components/StaminaComponent.swift
+++ b/ECS/Components/StaminaComponent.swift
@@ -1,0 +1,8 @@
+import RealityKit
+import Foundation
+
+struct StaminaComponent: Component {
+    var value: Float = 100
+    var max: Float = 100
+    var regen: Float = 10
+}

--- a/ECS/Components/StatusEffectComponent.swift
+++ b/ECS/Components/StatusEffectComponent.swift
@@ -1,0 +1,7 @@
+import RealityKit
+import Foundation
+
+struct StatusEffectComponent: Component {
+    var duration: TimeInterval = 0
+    var timer: TimeInterval = 0
+}

--- a/ECS/Components/WeaponComponent.swift
+++ b/ECS/Components/WeaponComponent.swift
@@ -1,0 +1,6 @@
+import RealityKit
+import Foundation
+
+struct WeaponComponent: Component {
+    var isFiring: Bool = false
+}

--- a/ECS/Systems/AIBehaviorSystem.swift
+++ b/ECS/Systems/AIBehaviorSystem.swift
@@ -1,0 +1,16 @@
+import RealityKit
+
+class AIBehaviorSystem: System {
+    private static let query = EntityQuery(where: .has(AIBehaviorComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var ai = entity.components[AIBehaviorComponent.self] {
+                            ai.state += 1
+                            entity.components.set(ai)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/AmmoSystem.swift
+++ b/ECS/Systems/AmmoSystem.swift
@@ -1,0 +1,17 @@
+import RealityKit
+
+class AmmoSystem: System {
+    private static let query = EntityQuery(where: .has(AmmoComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var ammo = entity.components[AmmoComponent.self] {
+                            if ammo.count > ammo.capacity { ammo.count = ammo.capacity }
+                            if ammo.count < 0 { ammo.count = 0 }
+                            entity.components.set(ammo)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/CollectibleSystem.swift
+++ b/ECS/Systems/CollectibleSystem.swift
@@ -1,0 +1,15 @@
+import RealityKit
+
+class CollectibleSystem: System {
+    private static let query = EntityQuery(where: .has(CollectibleComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var item = entity.components[CollectibleComponent.self] {
+                            if item.collected { entity.isEnabled = false }
+                        }
+        }
+    }
+}

--- a/ECS/Systems/CooldownSystem.swift
+++ b/ECS/Systems/CooldownSystem.swift
@@ -1,0 +1,22 @@
+import RealityKit
+
+class CooldownSystem: System {
+    private static let query = EntityQuery(where: .has(CooldownComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var cd = entity.components[CooldownComponent.self] {
+                            if !cd.ready {
+                                cd.timer += context.deltaTime
+                                if cd.timer >= cd.time {
+                                    cd.timer = 0
+                                    cd.ready = true
+                                }
+                            }
+                            entity.components.set(cd)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/DamageOverTimeSystem.swift
+++ b/ECS/Systems/DamageOverTimeSystem.swift
@@ -1,0 +1,18 @@
+import RealityKit
+
+class DamageOverTimeSystem: System {
+    private static let query = EntityQuery(where: .has(DamageOverTimeComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var dot = entity.components[DamageOverTimeComponent.self], var health = entity.components[HealthComponent.self] {
+                            if dot.rate > 0 {
+                                health.value -= dot.rate * Float(context.deltaTime)
+                                entity.components.set(health)
+                            }
+                        }
+        }
+    }
+}

--- a/ECS/Systems/DamageSystem.swift
+++ b/ECS/Systems/DamageSystem.swift
@@ -1,0 +1,20 @@
+import RealityKit
+
+class DamageSystem: System {
+    private static let query = EntityQuery(where: .has(DamageComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var damage = entity.components[DamageComponent.self], var health = entity.components[HealthComponent.self] {
+                            if damage.amount > 0 {
+                                health.value -= damage.amount
+                                damage.amount = 0
+                                entity.components.set(health)
+                                entity.components.set(damage)
+                            }
+                        }
+        }
+    }
+}

--- a/ECS/Systems/DialogSystem.swift
+++ b/ECS/Systems/DialogSystem.swift
@@ -1,0 +1,16 @@
+import RealityKit
+
+class DialogSystem: System {
+    private static let query = EntityQuery(where: .has(DialogComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var dialog = entity.components[DialogComponent.self] {
+                            dialog.index += 1
+                            entity.components.set(dialog)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/EnemySpawnSystem.swift
+++ b/ECS/Systems/EnemySpawnSystem.swift
@@ -1,0 +1,19 @@
+import RealityKit
+
+class EnemySpawnSystem: System {
+    private static let query = EntityQuery(where: .has(EnemySpawnComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var spawn = entity.components[EnemySpawnComponent.self] {
+                            spawn.timer += context.deltaTime
+                            if spawn.timer >= spawn.interval {
+                                spawn.timer = 0
+                            }
+                            entity.components.set(spawn)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/ExperienceSystem.swift
+++ b/ECS/Systems/ExperienceSystem.swift
@@ -1,0 +1,16 @@
+import RealityKit
+
+class ExperienceSystem: System {
+    private static let query = EntityQuery(where: .has(ExperienceComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var xp = entity.components[ExperienceComponent.self] {
+                            if xp.points < 0 { xp.points = 0 }
+                            entity.components.set(xp)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/FireRateSystem.swift
+++ b/ECS/Systems/FireRateSystem.swift
@@ -1,0 +1,22 @@
+import RealityKit
+
+class FireRateSystem: System {
+    private static let query = EntityQuery(where: .has(FireRateComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var fire = entity.components[FireRateComponent.self] {
+                            if !fire.canFire {
+                                fire.timer += context.deltaTime
+                                if fire.timer >= fire.interval {
+                                    fire.timer = 0
+                                    fire.canFire = true
+                                }
+                            }
+                            entity.components.set(fire)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/HealSystem.swift
+++ b/ECS/Systems/HealSystem.swift
@@ -1,0 +1,21 @@
+import RealityKit
+
+class HealSystem: System {
+    private static let query = EntityQuery(where: .has(HealComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var heal = entity.components[HealComponent.self], var health = entity.components[HealthComponent.self] {
+                            if heal.amount > 0 {
+                                health.value += heal.amount
+                                heal.amount = 0
+                                if health.value > health.max { health.value = health.max }
+                                entity.components.set(health)
+                                entity.components.set(heal)
+                            }
+                        }
+        }
+    }
+}

--- a/ECS/Systems/HealthSystem.swift
+++ b/ECS/Systems/HealthSystem.swift
@@ -1,0 +1,19 @@
+import RealityKit
+
+class HealthSystem: System {
+    private static let query = EntityQuery(where: .has(HealthComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var health = entity.components[HealthComponent.self] {
+                            health.value = min(max(health.value, 0), health.max)
+                            if health.value <= 0 {
+                                entity.isEnabled = false
+                            }
+                            entity.components.set(health)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/InputSystem.swift
+++ b/ECS/Systems/InputSystem.swift
@@ -1,0 +1,16 @@
+import RealityKit
+
+class InputSystem: System {
+    private static let query = EntityQuery(where: .has(InputComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var input = entity.components[InputComponent.self] {
+                            input.isActive = false
+                            entity.components.set(input)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/InteractionSystem.swift
+++ b/ECS/Systems/InteractionSystem.swift
@@ -1,0 +1,16 @@
+import RealityKit
+
+class InteractionSystem: System {
+    private static let query = EntityQuery(where: .has(InteractionComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var interact = entity.components[InteractionComponent.self] {
+                            interact.triggered = false
+                            entity.components.set(interact)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/InventorySystem.swift
+++ b/ECS/Systems/InventorySystem.swift
@@ -1,0 +1,15 @@
+import RealityKit
+
+class InventorySystem: System {
+    private static let query = EntityQuery(where: .has(InventoryComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var inv = entity.components[InventoryComponent.self] {
+                            entity.components.set(inv)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/LevelSystem.swift
+++ b/ECS/Systems/LevelSystem.swift
@@ -1,0 +1,16 @@
+import RealityKit
+
+class LevelSystem: System {
+    private static let query = EntityQuery(where: .has(LevelComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var level = entity.components[LevelComponent.self] {
+                            if level.value < 1 { level.value = 1 }
+                            entity.components.set(level)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/PathFollowSystem.swift
+++ b/ECS/Systems/PathFollowSystem.swift
@@ -1,0 +1,16 @@
+import RealityKit
+
+class PathFollowSystem: System {
+    private static let query = EntityQuery(where: .has(PathFollowComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var path = entity.components[PathFollowComponent.self] {
+                            path.index += 1
+                            entity.components.set(path)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/PickupSystem.swift
+++ b/ECS/Systems/PickupSystem.swift
@@ -1,0 +1,15 @@
+import RealityKit
+
+class PickupSystem: System {
+    private static let query = EntityQuery(where: .has(PickupComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var pickup = entity.components[PickupComponent.self] {
+                            if pickup.picked { entity.isEnabled = false }
+                        }
+        }
+    }
+}

--- a/ECS/Systems/QuestSystem.swift
+++ b/ECS/Systems/QuestSystem.swift
@@ -1,0 +1,15 @@
+import RealityKit
+
+class QuestSystem: System {
+    private static let query = EntityQuery(where: .has(QuestComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var quest = entity.components[QuestComponent.self] {
+                            if quest.completed { entity.isEnabled = false }
+                        }
+        }
+    }
+}

--- a/ECS/Systems/RespawnSystem.swift
+++ b/ECS/Systems/RespawnSystem.swift
@@ -1,0 +1,22 @@
+import RealityKit
+
+class RespawnSystem: System {
+    private static let query = EntityQuery(where: .has(RespawnComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var respawn = entity.components[RespawnComponent.self] {
+                            if !entity.isEnabled {
+                                respawn.timer += context.deltaTime
+                                if respawn.timer >= respawn.time {
+                                    respawn.timer = 0
+                                    entity.isEnabled = true
+                                }
+                                entity.components.set(respawn)
+                            }
+                        }
+        }
+    }
+}

--- a/ECS/Systems/ScoreSystem.swift
+++ b/ECS/Systems/ScoreSystem.swift
@@ -1,0 +1,16 @@
+import RealityKit
+
+class ScoreSystem: System {
+    private static let query = EntityQuery(where: .has(ScoreComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var score = entity.components[ScoreComponent.self] {
+                            if score.value < 0 { score.value = 0 }
+                            entity.components.set(score)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/ShieldSystem.swift
+++ b/ECS/Systems/ShieldSystem.swift
@@ -1,0 +1,17 @@
+import RealityKit
+
+class ShieldSystem: System {
+    private static let query = EntityQuery(where: .has(ShieldComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var shield = entity.components[ShieldComponent.self] {
+                            if shield.strength > shield.max { shield.strength = shield.max }
+                            if shield.strength < 0 { shield.strength = 0 }
+                            entity.components.set(shield)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/StaminaSystem.swift
+++ b/ECS/Systems/StaminaSystem.swift
@@ -1,0 +1,17 @@
+import RealityKit
+
+class StaminaSystem: System {
+    private static let query = EntityQuery(where: .has(StaminaComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var stamina = entity.components[StaminaComponent.self] {
+                            stamina.value += stamina.regen * Float(context.deltaTime)
+                            if stamina.value > stamina.max { stamina.value = stamina.max }
+                            entity.components.set(stamina)
+                        }
+        }
+    }
+}

--- a/ECS/Systems/StatusEffectSystem.swift
+++ b/ECS/Systems/StatusEffectSystem.swift
@@ -1,0 +1,20 @@
+import RealityKit
+
+class StatusEffectSystem: System {
+    private static let query = EntityQuery(where: .has(StatusEffectComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var effect = entity.components[StatusEffectComponent.self] {
+                            effect.timer += context.deltaTime
+                            if effect.timer >= effect.duration {
+                                entity.components.remove(StatusEffectComponent.self)
+                            } else {
+                                entity.components.set(effect)
+                            }
+                        }
+        }
+    }
+}

--- a/ECS/Systems/WeaponSystem.swift
+++ b/ECS/Systems/WeaponSystem.swift
@@ -1,0 +1,16 @@
+import RealityKit
+
+class WeaponSystem: System {
+    private static let query = EntityQuery(where: .has(WeaponComponent.self))
+
+    required init(scene: Scene) { }
+
+    func update(context: SceneUpdateContext) {
+        for entity in context.entities(matching: Self.query, updatingSystemWhen: .rendering) {
+                        if var weapon = entity.components[WeaponComponent.self] {
+                            weapon.isFiring = false
+                            entity.components.set(weapon)
+                        }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -167,6 +167,34 @@ https://github.com/user-attachments/assets/4157e76d-e3a4-4f8e-90a1-154af8d5f121
 | [ToggleVisibilityComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/ToggleVisibilityComponent.swift) | [ToggleVisibilitySystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/ToggleVisibilitySystem.swift) |
 
 
+### Game Mechanics
+| Component | System |
+| --- | --- |
+| [HealthComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/HealthComponent.swift) | [HealthSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/HealthSystem.swift) |
+| [DamageComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/DamageComponent.swift) | [DamageSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/DamageSystem.swift) |
+| [ScoreComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/ScoreComponent.swift) | [ScoreSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/ScoreSystem.swift) |
+| [CollectibleComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/CollectibleComponent.swift) | [CollectibleSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/CollectibleSystem.swift) |
+| [RespawnComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/RespawnComponent.swift) | [RespawnSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/RespawnSystem.swift) |
+| [AmmoComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/AmmoComponent.swift) | [AmmoSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/AmmoSystem.swift) |
+| [FireRateComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/FireRateComponent.swift) | [FireRateSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/FireRateSystem.swift) |
+| [StaminaComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/StaminaComponent.swift) | [StaminaSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/StaminaSystem.swift) |
+| [AIBehaviorComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/AIBehaviorComponent.swift) | [AIBehaviorSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/AIBehaviorSystem.swift) |
+| [PathFollowComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/PathFollowComponent.swift) | [PathFollowSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/PathFollowSystem.swift) |
+| [EnemySpawnComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/EnemySpawnComponent.swift) | [EnemySpawnSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/EnemySpawnSystem.swift) |
+| [PickupComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/PickupComponent.swift) | [PickupSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/PickupSystem.swift) |
+| [QuestComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/QuestComponent.swift) | [QuestSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/QuestSystem.swift) |
+| [DialogComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/DialogComponent.swift) | [DialogSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/DialogSystem.swift) |
+| [InputComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/InputComponent.swift) | [InputSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/InputSystem.swift) |
+| [WeaponComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/WeaponComponent.swift) | [WeaponSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/WeaponSystem.swift) |
+| [ShieldComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/ShieldComponent.swift) | [ShieldSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/ShieldSystem.swift) |
+| [DamageOverTimeComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/DamageOverTimeComponent.swift) | [DamageOverTimeSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/DamageOverTimeSystem.swift) |
+| [HealComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/HealComponent.swift) | [HealSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/HealSystem.swift) |
+| [StatusEffectComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/StatusEffectComponent.swift) | [StatusEffectSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/StatusEffectSystem.swift) |
+| [LevelComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/LevelComponent.swift) | [LevelSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/LevelSystem.swift) |
+| [ExperienceComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/ExperienceComponent.swift) | [ExperienceSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/ExperienceSystem.swift) |
+| [CooldownComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/CooldownComponent.swift) | [CooldownSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/CooldownSystem.swift) |
+| [InventoryComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/InventoryComponent.swift) | [InventorySystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/InventorySystem.swift) |
+| [InteractionComponent](https://github.com/IvanCampos/ECS/blob/main/ECS/Components/InteractionComponent.swift) | [InteractionSystem](https://github.com/IvanCampos/ECS/blob/main/ECS/Systems/InteractionSystem.swift) |
 ##  Developer Resources
 [Understanding the modular architecture of RealityKit](https://developer.apple.com/documentation/visionos/understanding-the-realitykit-modular-architecture)  
 [Implementing systems for entities in a scene](https://developer.apple.com/documentation/RealityKit/implementing-systems-for-entities-in-a-scene)  


### PR DESCRIPTION
## Summary
- add 25 new game-oriented components such as Health, Damage, Inventory, and Interaction
- implement matching systems to update each component every frame
- document all new component/system pairs in README under Game Mechanics

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d7a050e083208dcea32aab0e5dca